### PR TITLE
Remove (r)syslog dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,6 @@ Depends: cups,
          openssl,
          ${misc:Depends},
          ${python3:Depends},
-         rsyslog | system-log-daemon,
 Description: Google Cloud Print proxy
  Worker script to support a Google Cloud Print proxy. This can make
  locally-configured printers to be accessed by local or remote users over


### PR DESCRIPTION
Leave choice to local admin whether plain text system logs are needed or even wanted or if systemd-journald is sufficient.

Fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=954309

Signed-off-by: MichaIng <micha@dietpi.com>